### PR TITLE
Fixes relevant attribute broken when field name contains and/or expression

### DIFF
--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -10,10 +10,10 @@ class Expression
   end
 
   def kind; raise 'you have to implement in subclass' end
-  def exit_value; 'you have to implement in subclass' end
+  def exit_value; raise 'you have to implement in subclass' end
 
   def append_conditions! relevant_attr
-    relevant_attr.downcase.split(kind.to_s).each do |condition|
+    relevant_attr.downcase.split(" #{kind.to_s} ").each do |condition|
       conditions << Parsers::ConditionParser.parse(condition.strip)
     end
   end


### PR DESCRIPTION
- Fixed relevant attribute parser broker when field name contains and/or expression, in e.g: learn_more, ..etc.